### PR TITLE
fix(website): make mobile nav hamburger actually work

### DIFF
--- a/website/about.html
+++ b/website/about.html
@@ -182,5 +182,6 @@
         <span class="footer-copy">&copy; 2026 Cortex. </span>
       </div>
     </footer>
+    <script src="assets/nav.js" defer></script>
   </body>
 </html>

--- a/website/assets/nav.js
+++ b/website/assets/nav.js
@@ -1,0 +1,33 @@
+(function () {
+  const nav = document.querySelector(".nav");
+  const toggle = nav && nav.querySelector(".nav-toggle");
+  const links = nav && nav.querySelector(".nav-links");
+  if (!nav || !toggle || !links) return;
+
+  toggle.setAttribute("aria-expanded", "false");
+  toggle.setAttribute("aria-controls", "primary-nav");
+  links.id = links.id || "primary-nav";
+
+  const setOpen = (open) => {
+    nav.classList.toggle("is-open", open);
+    toggle.setAttribute("aria-expanded", open ? "true" : "false");
+  };
+
+  toggle.addEventListener("click", (event) => {
+    event.stopPropagation();
+    setOpen(!nav.classList.contains("is-open"));
+  });
+
+  links.querySelectorAll("a").forEach((link) => {
+    link.addEventListener("click", () => setOpen(false));
+  });
+
+  document.addEventListener("click", (event) => {
+    if (!nav.classList.contains("is-open")) return;
+    if (!nav.contains(event.target)) setOpen(false);
+  });
+
+  document.addEventListener("keydown", (event) => {
+    if (event.key === "Escape") setOpen(false);
+  });
+})();

--- a/website/index.html
+++ b/website/index.html
@@ -36,6 +36,21 @@
           </svg>
         </a>
       </div>
+      <button class="nav-toggle" aria-label="Menu">
+        <svg
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+        >
+          <line x1="3" y1="6" x2="21" y2="6" />
+          <line x1="3" y1="12" x2="21" y2="12" />
+          <line x1="3" y1="18" x2="21" y2="18" />
+        </svg>
+      </button>
     </nav>
 
     <main>
@@ -640,5 +655,6 @@
         .querySelectorAll(".anim-scroll")
         .forEach((el) => observer.observe(el));
     </script>
+    <script src="assets/nav.js" defer></script>
   </body>
 </html>

--- a/website/personalization.html
+++ b/website/personalization.html
@@ -178,5 +178,6 @@
         <span class="footer-copy">&copy; 2026 Cortex. </span>
       </div>
     </footer>
+    <script src="assets/nav.js" defer></script>
   </body>
 </html>

--- a/website/privacy-policy.html
+++ b/website/privacy-policy.html
@@ -214,5 +214,6 @@
         <span class="footer-copy">&copy; 2026 Cortex. </span>
       </div>
     </footer>
+    <script src="assets/nav.js" defer></script>
   </body>
 </html>

--- a/website/styles.css
+++ b/website/styles.css
@@ -199,6 +199,33 @@ main,
   height: 15px;
 }
 
+.nav-toggle {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  padding: 0;
+  border: 1px solid rgba(88, 67, 39, 0.12);
+  background: rgba(255, 250, 242, 0.74);
+  color: var(--text-primary);
+  border-radius: 12px;
+  cursor: pointer;
+  transition:
+    background 0.18s ease,
+    border-color 0.18s ease;
+}
+
+.nav-toggle:hover {
+  background: #fffaf2;
+  border-color: var(--border-hover);
+}
+
+.nav-toggle svg {
+  width: 22px;
+  height: 22px;
+}
+
 .hero {
   display: grid;
   grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr);
@@ -1195,23 +1222,42 @@ main,
   .nav {
     position: static;
     margin-top: 0.75rem;
-    padding: 1rem;
+    padding: 0.85rem 1rem;
     border-radius: 24px;
     flex-wrap: wrap;
+    justify-content: space-between;
+  }
+
+  .nav-toggle {
+    display: inline-flex;
   }
 
   .nav-links {
+    display: none;
+    order: 3;
     width: 100%;
-    flex-wrap: wrap;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.35rem;
+    margin-top: 0.85rem;
+    padding-top: 0.85rem;
+    border-top: 1px solid rgba(88, 67, 39, 0.12);
+  }
+
+  .nav.is-open .nav-links {
+    display: flex;
   }
 
   .nav-links a:not(.nav-cta) {
-    padding: 0.55rem 0.8rem;
+    padding: 0.75rem 0.9rem;
+    text-align: center;
+    font-size: 0.95rem;
+    border-radius: 14px;
   }
 
   .nav-cta {
     width: 100%;
-    margin-top: 0.25rem;
+    margin-top: 0.5rem;
   }
 
   .hero {

--- a/website/terms-of-service.html
+++ b/website/terms-of-service.html
@@ -202,5 +202,6 @@
         <span class="footer-copy">&copy; 2026 Cortex. </span>
       </div>
     </footer>
+    <script src="assets/nav.js" defer></script>
   </body>
 </html>

--- a/website/usage-policy.html
+++ b/website/usage-policy.html
@@ -198,5 +198,6 @@
         <span class="footer-copy">&copy; 2026 Cortex. </span>
       </div>
     </footer>
+    <script src="assets/nav.js" defer></script>
   </body>
 </html>


### PR DESCRIPTION
The nav-toggle button was rendered on every page but had no CSS or JS,
so on mobile the full link list wrapped awkwardly while the unstyled
hamburger did nothing when tapped. Add a styled nav-toggle, hide the
links by default under 760px, expose them via .nav.is-open, and wire
up a small nav.js that toggles state, closes on outside click, Escape,
or link tap. Also add the previously-missing nav-toggle button to
index.html so the landing page matches the rest of the site.

https://claude.ai/code/session_01K5w3ocHKMMvojh1iWa5H8q