### PR TITLE
fix(pwa): reserve space for iOS status bar in top bar and sidebar

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -30,11 +30,11 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0 1rem;
+  padding: env(safe-area-inset-top) 1rem 0;
   border-bottom: 1px solid var(--border-color);
   background: var(--bg-primary);
-  height: 52px;
-  min-height: 52px;
+  height: calc(52px + env(safe-area-inset-top));
+  min-height: calc(52px + env(safe-area-inset-top));
   flex-shrink: 0;
 }
 
@@ -603,9 +603,9 @@
 
   /* TopBar Mobile Optimization */
   .top-bar {
-    padding: 0 0.6rem;
-    height: 52px;
-    min-height: 52px;
+    padding: env(safe-area-inset-top) 0.6rem 0;
+    height: calc(52px + env(safe-area-inset-top));
+    min-height: calc(52px + env(safe-area-inset-top));
     position: sticky;
     top: 0;
     z-index: 100;
@@ -865,9 +865,9 @@
 /* Extra Small Mobile Devices (iPhone SE, small Android phones) */
 @media (max-width: 480px) {
   .top-bar {
-    padding: 0 0.5rem;
-    height: 44px;
-    min-height: 44px;
+    padding: env(safe-area-inset-top) 0.5rem 0;
+    height: calc(44px + env(safe-area-inset-top));
+    min-height: calc(44px + env(safe-area-inset-top));
   }
 
   .model-selector-trigger {
@@ -2757,6 +2757,8 @@ button.message-file-badge:hover {
     height: 100dvh;
     z-index: 101;
     animation: slideIn 0.2s ease;
+    padding-top: env(safe-area-inset-top);
+    padding-bottom: env(safe-area-inset-bottom);
   }
 }
 
@@ -6192,9 +6194,9 @@ button.message-file-badge:hover {
 
 /* ─── Top bar (contextual header, not brand) ─── */
 .top-bar {
-  height: 52px;
-  min-height: 52px;
-  padding: 0 1.25rem;
+  height: calc(52px + env(safe-area-inset-top));
+  min-height: calc(52px + env(safe-area-inset-top));
+  padding: env(safe-area-inset-top) 1.25rem 0;
   border-bottom: 1px solid rgba(88, 67, 39, 0.08);
   background: rgba(255, 255, 255, 0.62);
   backdrop-filter: blur(10px);
@@ -8652,9 +8654,9 @@ button.message-file-badge:hover {
 .top-bar {
   background: var(--paper);
   border-bottom: 1px solid var(--rule);
-  height: 48px;
-  min-height: 48px;
-  padding: 0 20px;
+  height: calc(48px + env(safe-area-inset-top));
+  min-height: calc(48px + env(safe-area-inset-top));
+  padding: env(safe-area-inset-top) 20px 0;
 }
 
 .top-bar.ghost-mode {


### PR DESCRIPTION
The installed PWA declares apple-mobile-web-app-status-bar-style
black-translucent with viewport-fit=cover, which draws the iOS status
bar over the top of the app. The top bar sat under the clock and
battery icons because it had no safe-area padding.

Add padding-top: env(safe-area-inset-top) on every .top-bar variant
(base + three theme overrides + two mobile breakpoints) and expand
heights via calc() so content isn't squished. Also pad the mobile
sidebar overlay at top and bottom so its header and footer clear the
status bar and home indicator.