### PR TITLE
feat(pwa): fix iOS status bar on /status, add dark mode, bump version

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -30,11 +30,32 @@
     <meta property="og:type" content="website" />
     <meta property="og:image" content="/IMG_6935.png" />
 
+    <script>
+      // Resolve theme before paint to avoid a flash of the wrong palette.
+      (function () {
+        try {
+          var stored = localStorage.getItem('cortex-theme')
+          var mode = stored === 'light' || stored === 'dark' || stored === 'system' ? stored : 'system'
+          var resolved =
+            mode === 'system'
+              ? window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
+                ? 'dark'
+                : 'light'
+              : mode
+          document.documentElement.dataset.theme = resolved
+          var meta = document.querySelector('meta[name="theme-color"]')
+          if (meta) meta.setAttribute('content', resolved === 'dark' ? '#15110e' : '#FAFAF7')
+        } catch (e) {}
+      })()
+    </script>
     <style>
       /* Initial loader - shown until React mounts */
       body {
         margin: 0;
         background: #fafaf7;
+      }
+      html[data-theme='dark'] body {
+        background: #15110e;
       }
       .initial-loader {
         display: flex;
@@ -45,6 +66,9 @@
         background: #fafaf7;
         color: #b8542c;
         font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      }
+      html[data-theme='dark'] .initial-loader {
+        background: #15110e;
       }
       .initial-loader h1 {
         font-size: 2rem;
@@ -58,6 +82,10 @@
         border-top-color: #b8542c;
         border-radius: 50%;
         animation: spin 1s linear infinite;
+      }
+      html[data-theme='dark'] .loader-spinner {
+        border-color: #2a221c;
+        border-top-color: #d97049;
       }
       @keyframes spin {
         to {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -4745,7 +4745,8 @@ button.message-file-badge:hover {
 .status-page {
   max-width: 720px;
   margin: 0 auto;
-  padding: 2rem 1.5rem;
+  padding: calc(2rem + env(safe-area-inset-top)) 1.5rem
+    calc(2rem + env(safe-area-inset-bottom));
   min-height: 100vh;
   min-height: 100dvh;
   background: var(--bg-primary);
@@ -10593,4 +10594,166 @@ button.message-file-badge:hover {
   .skeleton-message .skeleton-line-short {
     max-width: 100%;
   }
+}
+
+/* ========================================================================== */
+/* Dark theme surface overrides                                               */
+/*                                                                            */
+/* Most of the app is driven by semantic CSS variables (overridden in         */
+/* index.css), so dark mode "just works" for those rules. The block below     */
+/* patches the remaining places where translucent paper/white tints are       */
+/* hardcoded as rgba() — they look right on a paper background but burn       */
+/* white on a dark one.                                                       */
+/* ========================================================================== */
+html[data-theme='dark'] .chat-content {
+  border-left-color: var(--rule);
+}
+
+html[data-theme='dark'] .top-bar {
+  background: rgba(26, 22, 19, 0.72);
+  border-bottom-color: var(--rule);
+}
+
+html[data-theme='dark'] .top-bar.ghost-mode {
+  background: linear-gradient(180deg, var(--paper-2) 0%, var(--paper) 100%);
+}
+
+html[data-theme='dark'] .menu-btn,
+html[data-theme='dark'] .new-chat-btn,
+html[data-theme='dark'] .top-bar-action,
+html[data-theme='dark'] .top-bar-icon-btn,
+html[data-theme='dark'] .model-selector-trigger {
+  background: rgba(244, 236, 223, 0.04);
+  border-color: var(--rule);
+  color: var(--ink);
+}
+
+html[data-theme='dark'] .menu-btn:hover,
+html[data-theme='dark'] .new-chat-btn:hover,
+html[data-theme='dark'] .top-bar-action:hover,
+html[data-theme='dark'] .top-bar-icon-btn:hover,
+html[data-theme='dark'] .model-selector-trigger:hover {
+  background: rgba(244, 236, 223, 0.08);
+  border-color: var(--rule-2);
+}
+
+html[data-theme='dark'] .sidebar,
+html[data-theme='dark'] .sidebar-rail {
+  background: var(--paper);
+  border-color: var(--rule);
+}
+
+html[data-theme='dark'] .session-item,
+html[data-theme='dark'] .sidebar-session,
+html[data-theme='dark'] .session-card {
+  background: transparent;
+}
+
+html[data-theme='dark'] .session-item:hover,
+html[data-theme='dark'] .sidebar-session:hover,
+html[data-theme='dark'] .session-card:hover {
+  background: rgba(244, 236, 223, 0.05);
+}
+
+html[data-theme='dark'] .session-item.active,
+html[data-theme='dark'] .sidebar-session.active,
+html[data-theme='dark'] .session-card.active {
+  background: rgba(244, 236, 223, 0.08);
+}
+
+html[data-theme='dark'] .chat-input-wrapper,
+html[data-theme='dark'] .chat-input-bar,
+html[data-theme='dark'] .chat-input-container,
+html[data-theme='dark'] .chat-input {
+  background: rgba(244, 236, 223, 0.04);
+  border-color: var(--rule);
+  color: var(--ink);
+}
+
+html[data-theme='dark'] .chat-input::placeholder {
+  color: var(--muted);
+}
+
+html[data-theme='dark'] .message,
+html[data-theme='dark'] .message-bubble,
+html[data-theme='dark'] .message-content {
+  color: var(--ink);
+}
+
+html[data-theme='dark'] .message.user,
+html[data-theme='dark'] .message-user .message-bubble {
+  background: rgba(244, 236, 223, 0.06);
+  border-color: var(--rule);
+}
+
+html[data-theme='dark'] .welcome-screen,
+html[data-theme='dark'] .welcome-card,
+html[data-theme='dark'] .quick-action {
+  background: rgba(244, 236, 223, 0.04);
+  border-color: var(--rule);
+  color: var(--ink);
+}
+
+html[data-theme='dark'] .quick-action:hover {
+  background: rgba(244, 236, 223, 0.08);
+  border-color: var(--rule-2);
+}
+
+html[data-theme='dark'] .modal-overlay {
+  background: rgba(0, 0, 0, 0.65);
+}
+
+html[data-theme='dark'] .modal,
+html[data-theme='dark'] .settings-modal,
+html[data-theme='dark'] .command-palette,
+html[data-theme='dark'] .feedback-modal,
+html[data-theme='dark'] .keyboard-shortcuts-modal {
+  background: var(--paper);
+  border: 1px solid var(--rule);
+  color: var(--ink);
+}
+
+html[data-theme='dark'] code,
+html[data-theme='dark'] pre {
+  background: rgba(244, 236, 223, 0.06);
+}
+
+html[data-theme='dark'] .status-overall-icon {
+  background: rgba(244, 236, 223, 0.06);
+}
+
+html[data-theme='dark'] .status-incident-banner {
+  background: rgba(245, 158, 11, 0.1);
+  border-color: rgba(245, 158, 11, 0.3);
+  color: #f3c477;
+}
+
+html[data-theme='dark'] .status-overall-card {
+  background: rgba(47, 204, 102, 0.08);
+  border-color: rgba(47, 204, 102, 0.22);
+}
+
+html[data-theme='dark'] .status-overall-card.status-degraded {
+  background: rgba(245, 158, 11, 0.08);
+  border-color: rgba(245, 158, 11, 0.25);
+}
+
+html[data-theme='dark'] .status-overall-card.status-down {
+  background: rgba(220, 38, 38, 0.1);
+  border-color: rgba(220, 38, 38, 0.28);
+}
+
+html[data-theme='dark'] .status-overall-card.status-unknown {
+  background: rgba(244, 236, 223, 0.04);
+  border-color: var(--rule);
+}
+
+html[data-theme='dark'] .status-service-card {
+  background: rgba(244, 236, 223, 0.03);
+  border: 1px solid var(--rule);
+}
+
+html[data-theme='dark'] .top-bar-brand-link,
+html[data-theme='dark'] .top-bar-brand {
+  color: var(--ink);
 }

--- a/frontend/src/contexts/ThemeContext.tsx
+++ b/frontend/src/contexts/ThemeContext.tsx
@@ -1,0 +1,83 @@
+import { createContext, useContext, useEffect, useState, type ReactNode } from 'react'
+
+export type ThemeMode = 'light' | 'dark' | 'system'
+export type ResolvedTheme = 'light' | 'dark'
+
+interface ThemeContextValue {
+  theme: ThemeMode
+  resolvedTheme: ResolvedTheme
+  setTheme: (t: ThemeMode) => void
+}
+
+const STORAGE_KEY = 'cortex-theme'
+const LIGHT_BG = '#FAFAF7'
+const DARK_BG = '#15110e'
+
+const ThemeContext = createContext<ThemeContextValue | null>(null)
+
+function getSystemTheme(): ResolvedTheme {
+  if (typeof window === 'undefined' || !window.matchMedia) return 'light'
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+}
+
+function readStoredTheme(): ThemeMode {
+  try {
+    const v = localStorage.getItem(STORAGE_KEY)
+    if (v === 'light' || v === 'dark' || v === 'system') return v
+  } catch {
+    /* ignore */
+  }
+  return 'system'
+}
+
+function applyResolvedTheme(resolved: ResolvedTheme) {
+  document.documentElement.dataset.theme = resolved
+  const meta = document.querySelector('meta[name="theme-color"]')
+  if (meta) meta.setAttribute('content', resolved === 'dark' ? DARK_BG : LIGHT_BG)
+}
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setThemeState] = useState<ThemeMode>(readStoredTheme)
+  const [resolvedTheme, setResolvedTheme] = useState<ResolvedTheme>(() =>
+    readStoredTheme() === 'system' ? getSystemTheme() : (readStoredTheme() as ResolvedTheme)
+  )
+
+  useEffect(() => {
+    const next: ResolvedTheme = theme === 'system' ? getSystemTheme() : theme
+    setResolvedTheme(next)
+    applyResolvedTheme(next)
+  }, [theme])
+
+  useEffect(() => {
+    if (theme !== 'system' || !window.matchMedia) return
+    const mq = window.matchMedia('(prefers-color-scheme: dark)')
+    const handler = () => {
+      const next: ResolvedTheme = mq.matches ? 'dark' : 'light'
+      setResolvedTheme(next)
+      applyResolvedTheme(next)
+    }
+    mq.addEventListener('change', handler)
+    return () => mq.removeEventListener('change', handler)
+  }, [theme])
+
+  const setTheme = (t: ThemeMode) => {
+    setThemeState(t)
+    try {
+      localStorage.setItem(STORAGE_KEY, t)
+    } catch {
+      /* ignore */
+    }
+  }
+
+  return (
+    <ThemeContext.Provider value={{ theme, resolvedTheme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  )
+}
+
+export function useTheme() {
+  const ctx = useContext(ThemeContext)
+  if (!ctx) throw new Error('useTheme must be used within ThemeProvider')
+  return ctx
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -71,6 +71,83 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
+/* ─── Dark theme overrides ─── */
+html[data-theme='dark'] {
+  --paper: #1a1613;
+  --paper-2: #211c18;
+  --app-bg: #15110e;
+  --ink: #f4ecdf;
+  --ink-2: #cdbfae;
+  --muted: #8a7d6c;
+  --rule: #2c241d;
+  --rule-2: #3b3128;
+  --accent: #d97049;
+  --accent-dark: #b8542c;
+  --accent-light: rgba(217, 112, 73, 0.18);
+
+  --rule-soft: rgba(244, 236, 223, 0.06);
+  --ink-overlay: rgba(0, 0, 0, 0.45);
+  --accent-30: rgba(217, 112, 73, 0.3);
+  --accent-18: rgba(217, 112, 73, 0.18);
+
+  --bg-primary: var(--paper);
+  --bg-secondary: var(--paper);
+  --bg-tertiary: var(--paper-2);
+  --bg-hover: var(--paper-2);
+  --border-color: var(--rule);
+  --border-hover: var(--rule-2);
+  --border-soft: var(--rule-soft);
+  --text-primary: var(--ink);
+  --text-secondary: var(--ink-2);
+  --text-muted: var(--muted);
+  --accent-color: var(--accent);
+  --accent-hover: var(--accent-dark);
+  --heading-color: var(--ink);
+  --council-bg: var(--paper-2);
+  --chairman-bg: linear-gradient(135deg, rgba(217, 112, 73, 0.16) 0%, var(--paper-2) 100%);
+  --chairman-border: var(--accent-30);
+  --error-bg: rgba(220, 38, 38, 0.12);
+  --error-border: rgba(220, 38, 38, 0.32);
+  --panel-bg: rgba(26, 22, 19, 0.86);
+  --panel-strong: var(--paper);
+  --panel-warm: rgba(26, 22, 19, 0.6);
+  --shadow-soft: 0 20px 60px rgba(0, 0, 0, 0.5);
+  --shadow-subtle: 0 1px 3px rgba(0, 0, 0, 0.4);
+  --shadow-pop: 0 1px 2px rgba(0, 0, 0, 0.5), 0 8px 24px rgba(0, 0, 0, 0.4),
+    0 0 0 1px rgba(244, 236, 223, 0.06);
+  --shadow-ring: 0 0 0 3px rgba(217, 112, 73, 0.28);
+
+  color-scheme: dark;
+}
+
+html[data-theme='dark'] body,
+html[data-theme='dark'] #root {
+  background: var(--app-bg);
+  color: var(--ink);
+}
+
+html[data-theme='dark'] *::-webkit-scrollbar-thumb {
+  background: rgba(244, 236, 223, 0.1);
+  border: 3px solid transparent;
+  background-clip: padding-box;
+}
+html[data-theme='dark'] *::-webkit-scrollbar-thumb:hover {
+  background: rgba(244, 236, 223, 0.22);
+  border: 3px solid transparent;
+  background-clip: padding-box;
+}
+
+html[data-theme='dark'] kbd {
+  border-color: var(--rule-2);
+  background: var(--paper-2);
+  color: var(--ink);
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.4);
+}
+
+html[data-theme='dark'] ::selection {
+  background: rgba(217, 112, 73, 0.3);
+}
+
 * {
   box-sizing: border-box;
   margin: 0;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -8,6 +8,7 @@ import ProtectedRoute from './components/ProtectedRoute'
 import { AuthProvider } from './contexts/AuthContext'
 import { ToastProvider } from './contexts/ToastContext'
 import { UsageProvider } from './contexts/UsageContext'
+import { ThemeProvider } from './contexts/ThemeContext'
 
 // Lazy load pages - only load when needed
 const App = lazy(() => import('./App'))
@@ -20,38 +21,40 @@ const NotFoundPage = lazy(() => import('./pages/NotFoundPage'))
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <ErrorBoundary>
-      <AuthProvider>
-        <UsageProvider>
-          <ToastProvider>
-            <BrowserRouter>
-              <Suspense fallback={null}>
-                <Routes>
-                  {/* Public routes */}
-                  <Route path="/login" element={<AuthPage />} />
-                  <Route path="/register" element={<AuthPage />} />
-                  <Route path="/shared/:shareToken" element={<SharedSession />} />
-                  <Route path="/status" element={<StatusPage />} />
+      <ThemeProvider>
+        <AuthProvider>
+          <UsageProvider>
+            <ToastProvider>
+              <BrowserRouter>
+                <Suspense fallback={null}>
+                  <Routes>
+                    {/* Public routes */}
+                    <Route path="/login" element={<AuthPage />} />
+                    <Route path="/register" element={<AuthPage />} />
+                    <Route path="/shared/:shareToken" element={<SharedSession />} />
+                    <Route path="/status" element={<StatusPage />} />
 
-                  {/* Protected routes */}
-                  <Route
-                    element={
-                      <ProtectedRoute>
-                        <Layout />
-                      </ProtectedRoute>
-                    }
-                  >
-                    <Route path="/" element={<App />} />
-                    <Route path="/sessions/:sessionId" element={<App />} />
-                    <Route path="/settings" element={<SettingsPage />} />
-                  </Route>
-                  {/* 404 */}
-                  <Route path="*" element={<NotFoundPage />} />
-                </Routes>
-              </Suspense>
-            </BrowserRouter>
-          </ToastProvider>
-        </UsageProvider>
-      </AuthProvider>
+                    {/* Protected routes */}
+                    <Route
+                      element={
+                        <ProtectedRoute>
+                          <Layout />
+                        </ProtectedRoute>
+                      }
+                    >
+                      <Route path="/" element={<App />} />
+                      <Route path="/sessions/:sessionId" element={<App />} />
+                      <Route path="/settings" element={<SettingsPage />} />
+                    </Route>
+                    {/* 404 */}
+                    <Route path="*" element={<NotFoundPage />} />
+                  </Routes>
+                </Suspense>
+              </BrowserRouter>
+            </ToastProvider>
+          </UsageProvider>
+        </AuthProvider>
+      </ThemeProvider>
     </ErrorBoundary>
   </StrictMode>
 )

--- a/frontend/src/pages/Settings.css
+++ b/frontend/src/pages/Settings.css
@@ -1690,3 +1690,176 @@ label.settings-label {
   letter-spacing: -0.005em;
   color: var(--ink);
 }
+
+/* ─── Theme toggle ─── */
+.theme-toggle-group {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.6rem;
+  margin-top: 0.75rem;
+  max-width: 480px;
+}
+
+.theme-toggle-option {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.7rem 0.85rem;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  color: var(--text-primary);
+  font-family: inherit;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition:
+    border-color 0.15s,
+    background 0.15s,
+    box-shadow 0.15s;
+}
+
+.theme-toggle-option:hover {
+  border-color: var(--border-hover);
+}
+
+.theme-toggle-option.active {
+  border-color: var(--accent-color);
+  background: var(--accent-light);
+  box-shadow: 0 0 0 1px var(--accent-color) inset;
+}
+
+.theme-toggle-swatch {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  flex-shrink: 0;
+}
+
+.theme-swatch-light {
+  background: linear-gradient(135deg, #fafaf7 50%, #f0ece3 50%);
+}
+
+.theme-swatch-dark {
+  background: linear-gradient(135deg, #1a1613 50%, #2c241d 50%);
+  border-color: rgba(255, 255, 255, 0.18);
+}
+
+.theme-swatch-system {
+  background: linear-gradient(135deg, #fafaf7 50%, #1a1613 50%);
+}
+
+.theme-toggle-label {
+  font-weight: 500;
+}
+
+@media (max-width: 600px) {
+  .theme-toggle-group {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ─── Dark theme: settings page surfaces ─── */
+html[data-theme='dark'] .settings-page {
+  background: var(--app-bg);
+}
+
+html[data-theme='dark'] .settings-nav-item {
+  color: var(--text-secondary);
+}
+
+html[data-theme='dark'] .settings-nav-item:hover {
+  background: rgba(244, 236, 223, 0.05);
+  color: var(--text-primary);
+}
+
+html[data-theme='dark'] .settings-nav-item.active {
+  background: rgba(244, 236, 223, 0.08);
+  color: var(--text-primary);
+}
+
+html[data-theme='dark'] .settings-option,
+html[data-theme='dark'] .settings-action,
+html[data-theme='dark'] .profile-row,
+html[data-theme='dark'] .profile-table,
+html[data-theme='dark'] .usage-card,
+html[data-theme='dark'] .usage-meter,
+html[data-theme='dark'] .about-link-card,
+html[data-theme='dark'] .about-keyboard-shortcuts-card,
+html[data-theme='dark'] .export-format-option {
+  background: rgba(244, 236, 223, 0.04);
+  border-color: var(--rule);
+}
+
+html[data-theme='dark'] .settings-action.danger {
+  background: rgba(220, 38, 38, 0.06);
+  border-color: rgba(220, 38, 38, 0.22);
+}
+
+html[data-theme='dark'] .settings-select,
+html[data-theme='dark'] .settings-textarea,
+html[data-theme='dark'] .profile-inline-edit input,
+html[data-theme='dark'] .settings-password-form input,
+html[data-theme='dark'] .settings-delete-form input,
+html[data-theme='dark'] .custom-select-trigger {
+  background: rgba(244, 236, 223, 0.04);
+  border-color: var(--rule);
+  color: var(--ink);
+}
+
+html[data-theme='dark'] .settings-select:hover,
+html[data-theme='dark'] .custom-select-trigger:hover {
+  border-color: var(--rule-2);
+}
+
+html[data-theme='dark'] .custom-select-menu {
+  background: var(--paper);
+  border-color: var(--rule);
+}
+
+html[data-theme='dark'] .custom-select-option:hover {
+  background: rgba(244, 236, 223, 0.06);
+}
+
+html[data-theme='dark'] .custom-select-option.selected {
+  background: var(--accent-light);
+  color: var(--accent-color);
+}
+
+html[data-theme='dark'] .settings-divider {
+  background: var(--rule);
+}
+
+html[data-theme='dark'] .profile-value-pill {
+  background: rgba(244, 236, 223, 0.06);
+  color: var(--ink);
+}
+
+html[data-theme='dark'] .profile-action-link {
+  color: var(--accent-color);
+}
+
+html[data-theme='dark'] .modal,
+html[data-theme='dark'] .settings-modal {
+  background: var(--paper);
+  border: 1px solid var(--rule);
+  color: var(--ink);
+}
+
+html[data-theme='dark'] .modal-checkbox {
+  background: rgba(244, 236, 223, 0.04);
+  border-color: var(--rule);
+}
+
+html[data-theme='dark'] .theme-toggle-option {
+  background: rgba(244, 236, 223, 0.04);
+}
+
+html[data-theme='dark'] .theme-toggle-option.active {
+  background: rgba(217, 112, 73, 0.18);
+  box-shadow: 0 0 0 1px var(--accent-color) inset;
+}
+
+html[data-theme='dark'] .theme-toggle-swatch {
+  border-color: rgba(244, 236, 223, 0.18);
+}

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -4,6 +4,7 @@ import { ArrowLeftIcon as ArrowLeft } from '@phosphor-icons/react/ArrowLeft'
 import { Keyboard as KeyboardIcon } from '@phosphor-icons/react/Keyboard'
 import { useAuth } from '../contexts/AuthContext'
 import { useUsage } from '../contexts/UsageContext'
+import { useTheme, type ThemeMode } from '../contexts/ThemeContext'
 import useTitle from '../hooks/useTitle'
 import { useToast } from '../contexts/ToastContext'
 import { FRONTEND_VERSION, apiClient } from '../config/api'
@@ -47,6 +48,7 @@ function Settings() {
   useTitle('Settings')
   const { user, updateProfile, regenerateAvatar, changePassword, deleteAccount } = useAuth() as any
   const { showToast } = useToast()
+  const { theme, setTheme } = useTheme()
   const {
     current: usageCurrent,
     history: usageHistory,
@@ -665,6 +667,40 @@ function Settings() {
                   >
                     {profileSaving ? 'Saving...' : 'Save changes'}
                   </button>
+                </div>
+              </div>
+
+              <div className="settings-divider" />
+              <div className="settings-section">
+                <h2>Appearance</h2>
+                <p className="settings-field-hint" style={{ marginTop: '-0.25rem' }}>
+                  Choose how Cortex looks. "System" follows your device setting.
+                </p>
+                <div
+                  className="theme-toggle-group"
+                  role="radiogroup"
+                  aria-label="Theme preference"
+                >
+                  {(['light', 'dark', 'system'] as ThemeMode[]).map((mode) => (
+                    <button
+                      key={mode}
+                      type="button"
+                      role="radio"
+                      aria-checked={theme === mode}
+                      className={`theme-toggle-option ${theme === mode ? 'active' : ''}`}
+                      onClick={() => {
+                        setTheme(mode)
+                        showToast(
+                          `Theme set to ${mode === 'system' ? 'system default' : mode}`
+                        )
+                      }}
+                    >
+                      <span className={`theme-toggle-swatch theme-swatch-${mode}`} aria-hidden />
+                      <span className="theme-toggle-label">
+                        {mode === 'light' ? 'Light' : mode === 'dark' ? 'Dark' : 'System'}
+                      </span>
+                    </button>
+                  ))}
                 </div>
               </div>
 

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "1.9.2-beta"
+  "version": "2.0.0-beta"
 }


### PR DESCRIPTION
- Pad .status-page with env(safe-area-inset-top) so the System Status
  header clears the iOS status bar (same fix the top bar got in 5149805,
  but the status page renders outside the chat shell so it needs its own
  safe-area padding).

- Introduce a light/dark/system theme toggle:
  * New ThemeContext persists the preference to localStorage and
    follows prefers-color-scheme when set to "system".
  * Pre-mount script in index.html resolves the theme before paint to
    avoid a flash of the wrong palette and updates the meta theme-color.
  * html[data-theme='dark'] block in index.css remaps the paper palette
    and semantic aliases to dark equivalents.
  * Targeted dark overrides in App.css and Settings.css patch the spots
    where surfaces are tinted with hardcoded rgba() (top bar, sidebar,
    chat input, message bubbles, status cards, settings rows, etc).
  * Appearance section in Settings exposes the toggle.

- Bump version.json to 2.0.0-beta.