### PR TITLE
fix(theme): remove white halo behind mobile welcome input and clean user bubble

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -8104,11 +8104,20 @@ button.message-file-badge:hover {
     padding: 0.6rem 1rem calc(env(safe-area-inset-bottom, 0.5rem) + 0.5rem);
     background: linear-gradient(
       to bottom,
-      rgba(255, 250, 242, 0) 0%,
-      rgba(255, 250, 242, 0.92) 35%,
-      rgba(255, 250, 242, 1) 65%
+      rgba(250, 250, 247, 0) 0%,
+      var(--paper) 35%,
+      var(--paper) 100%
     );
     z-index: 5;
+  }
+
+  html[data-theme='dark'] .welcome-input-area {
+    background: linear-gradient(
+      to bottom,
+      rgba(22, 19, 16, 0) 0%,
+      var(--app-bg) 35%,
+      var(--app-bg) 100%
+    );
   }
 
   /* ── Input: hide "Attach file" text on mobile, keep icon only ── */
@@ -11151,8 +11160,8 @@ html[data-theme='dark'] .model-selector-dropdown {
 
 /* ─── Messages ─── */
 html[data-theme='dark'] .message.user .message-content {
-  background: rgba(236, 228, 214, 0.06);
-  border-color: var(--rule);
+  background: var(--paper-2);
+  border-color: var(--rule-2);
   color: var(--text-primary);
 }
 


### PR DESCRIPTION
The mobile welcome-input-area had a hardcoded cream gradient with no dark
override, producing a bright white halo behind the input on mobile dark mode.
Switched the gradient to use --paper / --app-bg tokens so it follows the
theme. Also swapped the user message bubble's translucent off-white fill
for var(--paper-2) so it reads as a solid dark surface instead of a light
overlay on the dark background.