### PR TITLE
fix: dark-mode user bubble + cold-start auth bypass

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -10691,8 +10691,8 @@ html[data-theme='dark'] .message-content {
 
 html[data-theme='dark'] .message.user,
 html[data-theme='dark'] .message-user .message-bubble {
-  background: rgba(244, 236, 223, 0.06);
-  border-color: var(--rule);
+  background: transparent;
+  border-color: transparent;
 }
 
 html[data-theme='dark'] .welcome-screen,
@@ -11160,8 +11160,8 @@ html[data-theme='dark'] .model-selector-dropdown {
 
 /* ─── Messages ─── */
 html[data-theme='dark'] .message.user .message-content {
-  background: var(--paper-2);
-  border-color: var(--rule-2);
+  background: transparent;
+  border-color: transparent;
   color: var(--text-primary);
 }
 

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -173,6 +173,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, [isLoading, networkError, user, restoreSession])
 
   const login = async (email: string, password: string) => {
+    // Discard any stale session so the background restore loop can't
+    // auto-restore old tokens over a failed login attempt during a
+    // cold-start network error.
+    clearTokens()
+    setUser(null)
+    setNetworkError(false)
     const res = await apiClient.post('/auth/login', { email, password })
     storeTokens(res.data.access_token, res.data.refresh_token)
     const meRes = await apiClient.get('/auth/me')
@@ -181,6 +187,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }
 
   const register = async (email: string, password: string) => {
+    clearTokens()
+    setUser(null)
+    setNetworkError(false)
     const res = await apiClient.post('/auth/register', { email, password })
     storeTokens(res.data.access_token, res.data.refresh_token)
     const meRes = await apiClient.get('/auth/me')


### PR DESCRIPTION
## Summary

Two fixes:

### 1. Mobile dark-mode user message bubble
The base layout in `App.css` already paints `.message.user` and `.message.user .message-content` as transparent (no bubble, plain left-aligned text), but the dark-mode overrides at lines 10692 and 11162 were re-applying `rgba(244,236,223,0.06)` and `var(--paper-2)` backgrounds, producing a visible lighter rectangle around the "You" message — most noticeable on mobile. Made both transparent so the user message blends with the page background.

### 2. Cold-start "wrong password accepted" bug
During a Render cold start, the `AuthContext` background `restoreSession()` retry loop could restore a previously stored session after the user had submitted a wrong password whose login request failed with a network error. Once Render warmed up, the retry called `/auth/me` with the old tokens, set `user`, and `AuthPage` redirected to `/` — making it look like the wrong password worked. After logout (which clears localStorage), the bug couldn't repeat — wrong password correctly failed.

The backend was always rejecting the wrong password correctly; the frontend was silently auto-restoring an old session. Fix: clear stored tokens and reset `user`/`networkError` state at the start of `login()` and `register()` so any explicit submitted attempt is the source of truth and can't be overwritten by the background retry.

## Test plan
- [ ] Mobile dark mode: verify the "You" message has no lighter rectangle around it
- [ ] Mobile light mode: verify the user bubble still renders as before (untouched)
- [ ] Cold-start auth: with old tokens in localStorage, force a backend cold start, submit wrong password — should show "Invalid email or password" or a network error, never auto-login
- [ ] Normal login still works with correct credentials
- [ ] Register flow still works

https://claude.ai/code/session_01WrcQ72ypSQKdssic3t6sPb

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrcQ72ypSQKdssic3t6sPb)_